### PR TITLE
Handle request errors

### DIFF
--- a/modules/client.js
+++ b/modules/client.js
@@ -174,6 +174,10 @@ Client.prototype.rootRequest = function (options) {
     }
   });
 
+  request.on('error', function(err) {
+    deferred.reject(err);
+  });
+
   var content = options.content || options.body; // body is deprecated
 
   if (content) {


### PR DESCRIPTION
When CouchDB isn't running, the request fails with `Unhandled 'error' event: ECONNREFUSED`, crashing my application. Attaching an error event listener and rejecting the promise would be a way to work around this.
